### PR TITLE
Set height of color bg on scores as percentage of overall votes

### DIFF
--- a/app/scripts/components/dashboard.jsx
+++ b/app/scripts/components/dashboard.jsx
@@ -1,8 +1,7 @@
 import React, { PropTypes } from 'react';
-import { max } from 'lodash';
 
 import Home from './icons/home';
-import X from './icons/x';
+import Topic from './topic';
 
 const Dashboard = React.createClass({
   propTypes: {
@@ -38,13 +37,6 @@ const Dashboard = React.createClass({
     e.preventDefault();
     this.props.add(this.state.newTopic.replace(/'/g, '%27'));
     this.setState({ newTopic: '' });
-  },
-
-  scoreClass(scores, score, colorName) {
-    const classList = `dashboard__score dashboard__score--${colorName}`;
-    const isMax = score === max(scores) && score > 0;
-
-    return isMax ? `${classList} dashboard__score--max` : classList;
   },
 
   render() {
@@ -93,23 +85,9 @@ const Dashboard = React.createClass({
               </tr>
             </thead>
             <tbody>
-              {topics.map(({ id, topic, red, amber, green }) => {
-                const colors = [red, amber, green];
-
-                return (
-                  <tr key={id}>
-                    <td>
-                      <button className="dashboard__btn" onClick={() => remove(id)}>
-                        <X className="dashboard__x" />
-                      </button>
-                      {topic.replace(/%27/g, "'")}
-                    </td>
-                    <td className={this.scoreClass(colors, red, 'red')}>{red}</td>
-                    <td className={this.scoreClass(colors, amber, 'amber')}>{amber}</td>
-                    <td className={this.scoreClass(colors, green, 'green')}>{green}</td>
-                  </tr>
-                );
-              })}
+              {topics.map(props =>
+                <Topic {...props} remove={remove} key={props.id} />
+              )}
             </tbody>
           </table>
           <div className="dashboard__delete">

--- a/app/scripts/components/score_bar.jsx
+++ b/app/scripts/components/score_bar.jsx
@@ -1,0 +1,16 @@
+import React, { PropTypes } from 'react';
+
+const ScoreBar = ({ voteCount, score, color }) => {
+  const classList = `dashboard__score-bg dashboard__score-bg--${color}`;
+  const height = (score / voteCount) * 100;
+
+  return (<span className={classList} style={{ height: `${height}%` }} />);
+};
+
+ScoreBar.propTypes = {
+  color: PropTypes.string.isRequired,
+  score: PropTypes.number.isRequired,
+  voteCount: PropTypes.number.isRequired,
+};
+
+export default ScoreBar;

--- a/app/scripts/components/topic.jsx
+++ b/app/scripts/components/topic.jsx
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react';
+
+import ScoreBar from './score_bar';
+import X from './icons/x';
+
+const Topic = ({ id, topic, red, amber, green, remove }) => {
+  const colors = [{ red }, { amber }, { green }];
+  const voteCount = red + amber + green;
+
+  return (
+    <tr>
+      <td>
+        <button className="dashboard__btn" onClick={() => remove(id)}>
+          <X className="dashboard__x" />
+        </button>
+        {topic.replace(/%27/g, "'")}
+      </td>
+      {colors.map((color) => {
+        const name = Object.keys(color)[0];
+        const score = Object.values(color)[0];
+
+        return (
+          <td className={`dashboard__score dashboard__score--${name}`} key={name}>
+            <ScoreBar voteCount={voteCount} score={score} color={name} />
+            <span className="dashboard__score-text">{score}</span>
+          </td>
+        );
+      })}
+    </tr>
+  );
+};
+
+Topic.propTypes = {
+  amber: PropTypes.number.isRequired,
+  green: PropTypes.number.isRequired,
+  id: PropTypes.number.isRequired,
+  red: PropTypes.number.isRequired,
+  remove: PropTypes.func.isRequired,
+  topic: PropTypes.string.isRequired,
+};
+
+export default Topic;

--- a/app/scripts/components/topic.jsx
+++ b/app/scripts/components/topic.jsx
@@ -1,10 +1,11 @@
 import React, { PropTypes } from 'react';
+import { map } from 'lodash';
 
 import ScoreBar from './score_bar';
 import X from './icons/x';
 
 const Topic = ({ id, topic, red, amber, green, remove }) => {
-  const colors = [{ red }, { amber }, { green }];
+  const colors = { red, amber, green };
   const voteCount = red + amber + green;
 
   return (
@@ -15,17 +16,12 @@ const Topic = ({ id, topic, red, amber, green, remove }) => {
         </button>
         {topic.replace(/%27/g, "'")}
       </td>
-      {colors.map((color) => {
-        const name = Object.keys(color)[0];
-        const score = Object.values(color)[0];
-
-        return (
-          <td className={`dashboard__score dashboard__score--${name}`} key={name}>
-            <ScoreBar voteCount={voteCount} score={score} color={name} />
-            <span className="dashboard__score-text">{score}</span>
-          </td>
-        );
-      })}
+      {map(colors, (score, name) => (
+        <td className={`dashboard__score dashboard__score--${name}`} key={name}>
+          <ScoreBar voteCount={voteCount} score={score} color={name} />
+          <span className="dashboard__score-text">{score}</span>
+        </td>
+      ))}
     </tr>
   );
 };

--- a/app/styles/components/dashboard.scss
+++ b/app/styles/components/dashboard.scss
@@ -48,34 +48,44 @@
   }
 
   &__score {
+    font-weight: 700;
+    position: relative;
     text-align: center;
-
-    &--max {
-      font-weight: 700;
-    }
 
     &--red {
       color: $state-danger-text;
-
-      &.dashboard__score--max {
-        background-color: $state-danger-bg;
-      }
     }
 
     &--amber {
       color: $state-warning-text;
-
-      &.dashboard__score--max {
-        background-color: $state-warning-bg;
-      }
     }
 
     &--green {
       color: $state-success-text;
+    }
+  }
 
-      &.dashboard__score--max {
-        background-color: $state-success-bg;
-      }
+  &__score-text {
+    position: relative;
+  }
+
+  &__score-bg {
+    bottom: 0;
+    content: "";
+    left: 0;
+    position: absolute;
+    width: 100%;
+
+    &--red {
+      background-color: $state-danger-bg;
+    }
+
+    &--amber {
+      background-color: $state-warning-bg;
+    }
+
+    &--green {
+      background-color: $state-success-bg;
     }
   }
 


### PR DESCRIPTION
Currently when the top score for a topic is highlighted, it's the same visually whether that is an outright or a narrow winner.

![screen shot 2017-03-31 at 15 42 28](https://cloud.githubusercontent.com/assets/12033907/24555370/d2a6703a-1628-11e7-934c-526555d54670.png)

This release changes the background colour to a bar graph style, to get a better visualisation for how the votes are spread out.

![screen shot 2017-03-31 at 15 41 17](https://cloud.githubusercontent.com/assets/12033907/24555403/f14dc524-1628-11e7-9a15-f25488ca17b4.png)

Related to https://github.com/jstarmx/hot-topic/issues/8