### PR TITLE
Force Question Sort by ID

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -14,7 +14,7 @@ const getTitle = room =>
 const fetch = (room) => {
   const payload = { room };
 
-  return pool.query(`SELECT * FROM ${room}`)
+  return pool.query(`SELECT * FROM ${room} ORDER BY ID ASC`)
     .then((res) => {
       payload.data = res.rows;
       return room !== 'sessions' ? getTitle(room) : Promise.resolve;


### PR DESCRIPTION
We think that because we're not sorting by ID and sometimes the
Postgres database seems to inser them in a random position this
is causing the app to become confused on what the next question is.